### PR TITLE
Fixed a small typo in the Readme.md file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configuration for `p5.js` and all plugins
 ```
 {
     "extends": [
-        "p5js"
+        "p5js",
         "p5js/sound"
     ]
 }


### PR DESCRIPTION
There wasn't a comma to separate the elements in the 'extends' attribute array,
therefore a comma was added. 

Thanks